### PR TITLE
Attempt to add mpld3 package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,3 +37,4 @@ RUN apt-get install -y wget unzip && \
 
     # TensorFlow
 RUN pip install --upgrade https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-0.6.0-cp34-none-linux_x86_64.whl
+RUN pip install --upgrade mpld3


### PR DESCRIPTION
MPLD3 is a cool library that brings interactive matplotlib to python. I think it must be on Kaggle.
Check http://mpld3.github.io/ for details.
